### PR TITLE
I. #34 adding popover info for legend.

### DIFF
--- a/map-viewer/src/Map.css
+++ b/map-viewer/src/Map.css
@@ -83,7 +83,7 @@
   background-color:transparent;
   font-size: 18px;
   padding: 0;
-  padding-left: 0.5rem;
+  padding-left: 0.0rem;
   margin: 0;
   border: 0;
   outline-style: none;
@@ -185,7 +185,7 @@
 }
 .d3-legend {
   z-index: 1;
-  width: 300px;
+  width: 220px;
   height: 20px;
 }
 .d3-x-axis:not(:last-child) {

--- a/map-viewer/src/components/InfoPopover.jsx
+++ b/map-viewer/src/components/InfoPopover.jsx
@@ -32,7 +32,7 @@ const InfoPopover = (props) => {
   }
 
   return (
-    <OverlayTrigger trigger="click" rootClose placement="right" overlay={popover}>
+    <OverlayTrigger trigger="click" rootClose placement="auto" overlay={popover}>
       <Button variant="info" className="button-info" bsPrefix="info-btn">
         <BsInfoCircle />
       </Button>

--- a/map-viewer/src/components/Legend.jsx
+++ b/map-viewer/src/components/Legend.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import ListGroup from 'react-bootstrap/ListGroup';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
 
 import D3Legend from './D3Legend';
+import InfoPopover from './InfoPopover';
 
 const legendStyle = {
   'sediment': {
@@ -36,7 +39,19 @@ const Legend = (props) => {
       return (
         <ListGroup.Item key={`legendStyle-${i}`} className="legend-container">
           <div className="legend-desc">{legendStyle[serviceType].desc}</div>
-          <D3Legend serviceType={serviceType} legendStyle={legendStyle}/>
+          <Row>
+            <Col>
+              <D3Legend serviceType={serviceType} legendStyle={legendStyle}/>
+            </Col>
+            <Col xs="auto">
+              <InfoPopover
+                key={`legend-popover-${serviceType}`}
+                content={
+                  `Low = 1st percentile, Medium = 50th percentile, High = 99th
+                  percentile, scaled based on the chosen area of focus.`}
+              />
+            </Col>
+          </Row>
         </ListGroup.Item>
       );
   };


### PR DESCRIPTION
This adds an info button to the right of the legend for clarifying text about the scale. Did some light CSS work to make this look good.

Fixes #34 