### PR TITLE
Add protected layers

### DIFF
--- a/data/merge_vectors.py
+++ b/data/merge_vectors.py
@@ -27,6 +27,18 @@ def build_vector_path_list(vector_directory):
 
     return vector_list
 
+def build_vector_recursive_path_list(vector_directory):
+    vector_list = []
+    for root, dirs, files in os.walk(vector_directory):
+        for file in files:
+            if file.endswith(".shp") and "protected_points" not in file:
+                vector_list.append(os.path.join(root, file))
+            if file.endswith(".gpkg"):
+                vector_list.append(os.path.join(root, file))
+    #LOGGER.info(vector_list)
+    return vector_list
+    #return []
+
 if __name__ == "__main__":
 
     LOGGER.debug("Starting Merge Processing")
@@ -39,20 +51,47 @@ if __name__ == "__main__":
         'C:', os.sep, 'Users', 'ddenu', 'Workspace', 'NatCap', 'Repositories',
         'global-web-viewer', 'processed-data', 'gadm_stats_vectors')
 
+    protected_root_dir = os.path.join(
+        'C:', os.sep, 'Users', 'ddenu', 'Workspace', 'NatCap', 'Repositories',
+        'global-web-viewer', 'data', 'boundaries', 'Global-Protected-Areas')
+    protected_sub_dir = "all"
+
+    #protected_sub_dir = "Africa"
+    #protected_sub_dir = "Asia_and_Pacific"
+    #protected_sub_dir = "Europe"
+    #protected_sub_dir = "LatinAmerica_Caribbean"
+    #protected_sub_dir = "NorthAmerica"
+    #protected_sub_dir = "Polar"
+    protected_sub_dir = "WestAsia"
+    protected_root_dir = os.path.join(
+        'C:', os.sep, 'Users', 'ddenu', 'Workspace', 'NatCap', 'Repositories',
+        'global-web-viewer', 'data', 'boundaries', 'Global-Protected-Areas',
+        f'WDPA_WDOECM_Mar2021_Public_{protected_sub_dir}_shp')
+
     gadm0_process_dir = os.path.join(
         gadm0_root_dir, 'gadm36_0_clipped_stats')
 
-    gadm0_path_list = build_vector_path_list(gadm0_process_dir)
+    protected_process_dir = os.path.join(
+        protected_root_dir, f'protected_polys_merged_{protected_sub_dir}')
+    #protected_process_dir = os.path.join(
+    #    protected_root_dir, f'protected_points_merged_{protected_sub_dir}')
 
-    merge_hybas = True
+    gadm0_path_list = build_vector_path_list(gadm0_process_dir)
+    protected_path_list = build_vector_recursive_path_list(protected_root_dir)
+
+    merge_hybas = False
     merge_gadm0 = False
+    merge_protected = True
+    geom_type = "polygons"
+    #geom_type = "points"
+
 
     if merge_hybas:
         hybas_id = 'acc'
         hybas_process_dir = os.path.join(
             hybas_root_dir, f'hybas_{hybas_id}_processed_vectors')
         hybas_path_list = build_vector_path_list(hybas_process_dir)
-        
+
         # Refine hydro files by level
         file_matcher = f'{hybas_id}_perc'
         hybas_selected_path_list = [x for x in hybas_path_list if file_matcher in x]
@@ -110,5 +149,36 @@ if __name__ == "__main__":
                 subprocess.run(
                     ["ogr2ogr", "-f", "ESRI Shapefile", "-append", "-update",
                      merged_out_path, gadm_path])
+
+            LOGGER.debug(f"{idx + 1} out of {number_of_vectors} merged")
+    
+    if merge_protected:
+        merged_out_dir = os.path.join(
+            protected_process_dir, f'merged_vectors')
+        if not os.path.isdir(merged_out_dir):
+            os.makedirs(merged_out_dir)
+
+        merged_out_path = os.path.join(
+            merged_out_dir, f"protected_{geom_type}_{protected_sub_dir}.shp")
+        # if this file already exists, then remove it
+        if os.path.isfile(merged_out_path):
+            os.remove(merged_out_path)
+        
+        file_matcher = f'{geom_type}'
+        protected_selected_path_list = [x for x in protected_path_list if file_matcher in x]
+
+        number_of_vectors = len(protected_selected_path_list)
+
+        for idx, protected_path in enumerate(protected_selected_path_list):
+            if idx == 0:
+                # ogr2ogr -f "ESRI Shapefile" merged a.ship
+                # ogr2ogr -f "GeoJSONSeq" merged a.ship
+                subprocess.run(
+                    ["ogr2ogr", "-f", "ESRI Shapefile", merged_out_path, protected_path])
+            else:
+                # ogr2ogr -f "ESRI Shapefile" -append -update merged b.ship
+                subprocess.run(
+                    ["ogr2ogr", "-f", "ESRI Shapefile", "-append", "-update",
+                     merged_out_path, protected_path])
 
             LOGGER.debug(f"{idx + 1} out of {number_of_vectors} merged")

--- a/map-viewer/src/LayerDefinitions.js
+++ b/map-viewer/src/LayerDefinitions.js
@@ -489,6 +489,174 @@ const mapLayers = [
       },
     }
   },
+  {
+    layerID: 'protected-points',
+    name: 'Protected points',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-points',
+      'source-layer': 'protected_points_all_no_duplicatesgeojsonl',
+      type: 'circle',
+      paint: {
+        'circle-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.b29f9oyl',
+      },
+    }
+  },
+  {
+    layerID: 'protected-asia-pacific',
+    name: 'Protected Asia and Pacific',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-asia-pacific',
+      'source-layer': 'protected_polygons_Asia_and_Pacific',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.9es2n1jq',
+      },
+    }
+  },
+  {
+    layerID: 'protected-la-caribbean',
+    name: 'Protected Latin America and Caribbean',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-la-caribbean',
+      'source-layer': 'protected_polygons_LatinAmerica_Caribbean',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.d4a9sff0',
+      },
+    }
+  },
+  {
+    layerID: 'protected-af-polar-wa',
+    name: 'Protected Africa, Polar, West Asia',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-af-polar-wa',
+      'source-layer': 'protected_polygons_Africa_Polar_WestAsia',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.71dz1ont',
+      },
+    }
+  },
+  {
+    layerID: 'protected-north-america',
+    name: 'Protected North America',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-north-america',
+      'source-layer': 'protected_polygons_NorthAmerica',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.77rrl311',
+      },
+    }
+  },
+  {
+    layerID: 'protected-eu-0',
+    name: 'Protected Europe 0',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-eu-0',
+      'source-layer': 'protected_polygon_Europe_0',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.8yydsukv',
+      },
+    }
+  },
+  {
+    layerID: 'protected-eu-1',
+    name: 'Protected Europe 1',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-eu-1',
+      'source-layer': 'protected_polygon_Europe_1',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.9hiyxrqz',
+      },
+    }
+  },
+  {
+    layerID: 'protected-eu-2',
+    name: 'Protected Europe 2',
+    serviceType: 'protected-areas',
+    scaleID: 'all',
+    mapLayer: {
+      id: 'protected-eu-2',
+      'source-layer': 'protected_polygon_Europe_2',
+      type: 'fill',
+      paint: {
+        'fill-color': '#31a335',
+      },
+      layout: {
+        visibility: 'none',
+      },
+      source: {
+        type: 'vector',
+        url: 'mapbox://ddenu.protected-EU-2',
+      },
+    }
+  },
 ]
 
 export default mapLayers;

--- a/map-viewer/src/Map.css
+++ b/map-viewer/src/Map.css
@@ -44,6 +44,7 @@
   z-index: 1;
 }
 
+/* TOGGLE CSS */
 .custom-control-input:focus ~ .custom-control-label::before {
 /* when the button is toggled off it is still in focus and a green border will appear */
   border-color: #009b76 !important;
@@ -66,6 +67,7 @@
   border-color: #009b76 !important;
 }
 
+/* POPOVER CSS */
 .popover-body {
   font-family: 'Source Sans Pro', sans-serif;
 }
@@ -82,6 +84,7 @@
   font-size: 20px;
 }
 
+/* INFO BUTTON CSS */
 .btn {
   outline: none;
   box-shadow:none;
@@ -116,6 +119,7 @@
   padding-left: .3rem;
 }
 
+/* BASEMAP CSS */
 .basemap-control {
   z-index: 1;
   position: absolute;
@@ -163,6 +167,7 @@
   padding: 0.25rem;
 }
 
+/* LEGEND CSS */
 .legend-group {
   font-family: 'Source Sans Pro', sans-serif;
   z-index: 1;
@@ -208,6 +213,12 @@
   height: 200px;
   overflow-y: auto;
 }
+.d3-legend.ordinal.protected-areas{
+  z-index: 1;
+  width: 220px;
+  height: 20px;
+  overflow-y: auto;
+}
 .d3-x-axis:not(:last-child) {
   padding-right: 4.75rem;
 }
@@ -222,6 +233,7 @@
   cursor: pointer;
 }
 
+/* MAPBOX POPUP CSS */
 .mapboxgl-popup {
   padding-bottom: 20px;
   width: 280px;
@@ -277,19 +289,18 @@
   font-weight: 200;
   /*float: right;*/
 }
- 
 .mapboxgl-popup-content div {
   padding: 10px;
 }
- 
+
 .mapboxgl-container .leaflet-marker-icon {
   cursor: pointer;
 }
- 
+
 .mapboxgl-popup-anchor-top > .mapboxgl-popup-content {
   margin-top: 15px;
 }
- 
+
 .mapboxgl-popup-anchor-top > .mapboxgl-popup-tip {
   border-bottom-color: #91c949;
 }

--- a/map-viewer/src/Map.jsx
+++ b/map-viewer/src/Map.jsx
@@ -16,6 +16,7 @@ import Legend from './components/Legend';
 import BasemapControl from './components/BasemapControl';
 import mapLayers from './LayerDefinitions';
 import { coastalHabitats } from './ScaleDefinitions';
+import { protectedLayers } from './ScaleDefinitions';
 
 // import MyComponent from './components/MyComponent';
 
@@ -23,6 +24,10 @@ import { coastalHabitats } from './ScaleDefinitions';
 mapboxgl.accessToken =
   'pk.eyJ1IjoiZGRlbnUiLCJhIjoiY2ttZjQwamU2MTE1bjJ3bGpmZGZncG52NCJ9.u2cSHaEPPDgZH7PYBZNhWw';
 
+const multiFileLayers = {
+  'coastal-habitat': coastalHabitats,
+  'protected-areas': protectedLayers,
+}
 
 const Map = () => {
 
@@ -531,16 +536,15 @@ const Map = () => {
       setServices([...selectedServicesUpdate]);
 
       const layer = visibleLayers[serviceResult];
-      if(serviceResult !== "coastal-habitat") {
-        map.setLayoutProperty(layer.layerID, 'visibility', 'none');
-        delete visibleLayersUpdate[serviceResult];
+      if(serviceResult in multiFileLayers) {
+        multiFileLayers[serviceResult].forEach((childLayer) => {
+            map.setLayoutProperty(childLayer.id, 'visibility', 'none');
+            delete visibleLayersUpdate[childLayer.id];
+        });
       }
       else {
-        //delete visibleLayersUpdate[serviceResult];
-        coastalHabitats.forEach((chLayer) => {
-            map.setLayoutProperty(chLayer.id, 'visibility', 'none');
-            delete visibleLayersUpdate[chLayer.id];
-        });
+        map.setLayoutProperty(layer.layerID, 'visibility', 'none');
+        delete visibleLayersUpdate[serviceResult];
       }
       setLayers({...visibleLayersUpdate});
     }

--- a/map-viewer/src/ScaleDefinitions.js
+++ b/map-viewer/src/ScaleDefinitions.js
@@ -456,18 +456,10 @@ export const supportMenuDetails = [
       ],
     },
     {
-      id: "rivers",
-      label: "Rivers",
+      id: "protected-areas",
+      label: "Protected Areas",
       helpText: {
-        text: `The InVEST Sediment and Nutrient models trace the path of
-        erosion and nutrient from their origins until they reach a stream.
-        While in-stream processes are not modelled, the assumption is that
-        once these reach a river, they can cause water quality issues for
-        people and infrastructure downstream. So, it is often useful to
-        visualize rivers along with hydrologic service maps, to understand
-        which rivers and downstream communities are likely to benefit when
-        natural lands hold back sediment and nutrient from entering the
-        water supply.  `,
+        text: ``,
         metric: "N/A",
         source: "",
         resolution: "",
@@ -482,14 +474,22 @@ export const supportMenuDetails = [
           link: "",
         },
       },
-      iconKey: "ioiosconstruct",
-      disable: true,
+      iconKey: "filock",
+      disable: false,
     },
     {
-      id: "protected",
-      label: "Protected Areas",
+      id: "rivers",
+      label: "Rivers",
       helpText: {
-        text: ``,
+        text: `The InVEST Sediment and Nutrient models trace the path of
+        erosion and nutrient from their origins until they reach a stream.
+        While in-stream processes are not modelled, the assumption is that
+        once these reach a river, they can cause water quality issues for
+        people and infrastructure downstream. So, it is often useful to
+        visualize rivers along with hydrologic service maps, to understand
+        which rivers and downstream communities are likely to benefit when
+        natural lands hold back sediment and nutrient from entering the
+        water supply.  `,
         metric: "N/A",
         source: "",
         resolution: "",
@@ -658,6 +658,209 @@ export const coastalHabitats = [
       disable: true,
       subLayer: true,
       subLayerParent: "cvhabs",
+      legend: false,
+    },
+]
+
+export const protectedLayers = [
+    {
+      id: "protected-points",
+      label: "Protected points",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-asia-pacific",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-la-caribbean",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-af-polar-wa",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-north-america",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-eu-0",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-eu-1",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
+      legend: false,
+    },
+    {
+      id: "protected-eu-2",
+      label: "Protected areas",
+      helpText: {
+        text: ``,
+        metric: "N/A",
+        source: "",
+        resolution: "",
+        date: "",
+        coverage: "Global",
+        license: {
+          link: "",
+          text: "",
+        },
+        citation: {
+          text: ``,
+          link: "",
+        },
+      },
+      iconKey: "ioiosconstruct",
+      disable: true,
+      subLayer: true,
+      subLayerParent: "protected-areas",
       legend: false,
     },
 ]

--- a/map-viewer/src/components/D3Legend.jsx
+++ b/map-viewer/src/components/D3Legend.jsx
@@ -17,6 +17,7 @@ function formatColors(colors, numberStops) {
 const D3Legend = (props) => {
 
   const d3Container = useRef(null);
+  const legendType = props.legendStyle[props.serviceType].type;
   //const svgEl = d3.select(d3Container.current);
   //svgEl.selectAll("*").remove();
 
@@ -33,7 +34,7 @@ const D3Legend = (props) => {
       // function, like ComponentWillUnmount
       svg.selectAll("*").remove();
 
-      if(props.legendStyle[props.serviceType].type === 'ordinal'){
+      if(legendType === 'ordinal'){
         const keys = props.legendStyle[props.serviceType].colorKeys;
         const colors = props.legendStyle[props.serviceType].colors;
 
@@ -105,7 +106,7 @@ const D3Legend = (props) => {
   return (
     <>
       <svg
-        className={"d3-legend " + props.legendStyle[props.serviceType].type}
+        className={`d3-legend ${legendType} ${props.serviceType}`}
         ref={d3Container}
       />
       {props.legendStyle[props.serviceType].type !== 'ordinal' &&

--- a/map-viewer/src/components/LayerSelect.jsx
+++ b/map-viewer/src/components/LayerSelect.jsx
@@ -7,6 +7,7 @@ import { BiWater } from 'react-icons/bi';
 import { TiTree } from 'react-icons/ti';
 import { MdLandscape } from 'react-icons/md';
 import { IoIosPeople, IoIosConstruct } from 'react-icons/io';
+import { FiLock } from 'react-icons/fi';
 
 import Form from 'react-bootstrap/Form';
 import Col from 'react-bootstrap/Col';
@@ -24,6 +25,7 @@ const IconMap = {
   ioiosconstruct: <IoIosConstruct className="labelIcons"/>,
   mdlandscape: <MdLandscape className="labelIcons"/>,
   gicoral: <GiCoral className="labelIcons"/>,
+  filock: <FiLock className="labelIcons"/>,
 }
 
 const LayerSelect = (props) => {

--- a/map-viewer/src/components/Legend.jsx
+++ b/map-viewer/src/components/Legend.jsx
@@ -91,6 +91,15 @@ const legendStyle = {
       '#D4B577', '#FC8D62', '#FFEC42', '#CA7AF5', '#99CF78', '#6FACED'],
     info: 'Coastal and marine habitats',
   },
+  'protected-areas': {
+    id: 'protected-areas',
+    name: 'Protected areas',
+    desc: 'Protected areas',
+    type: 'ordinal',
+    colorKeys: ['Protected'],
+    colors: ['#31a335'],
+    info: 'Terrestrial and coastal protected areas',
+  },
 }
 
 

--- a/map-viewer/src/components/VerticalMenu.jsx
+++ b/map-viewer/src/components/VerticalMenu.jsx
@@ -112,7 +112,7 @@ const VerticalMenu = (props) => {
         <Card>
           <Accordion.Toggle as={Card.Header} eventKey="2" className="accordion-header">
             <Row>
-              <Col>3) Explore Other Layers -- Coming Soon</Col>
+              <Col>3) Explore Other Layers</Col>
               <Col xs="auto"><IoIosArrowDropdown className="dropdown-icon"/></Col>
             </Row>
           </Accordion.Toggle>


### PR DESCRIPTION
This PR adds a protected layer toggle that shows global protected areas. This layer was processed by merging the sub component shapefiles to a larger collection to a file size where we could still upload via free mapbox tier. This means we have to handle a lot of individual mapbox layers and treat them as one in the viewer.


Fixes #62 