### PR TITLE
Fix layering bug

### DIFF
--- a/map-viewer/src/Map.jsx
+++ b/map-viewer/src/Map.jsx
@@ -517,10 +517,8 @@ const Map = () => {
     console.log("change scale vis lay: ", visibleLayers);
     mapLayers.forEach((layer) => {
       if(layer.scaleID === scaleResult && currentServices.includes(layer.serviceType)) {
-        console.log("change scale show: ", layer.layerID);
         visibleLayersUpdate[layer.serviceType] = layer;
         visibleVar = 'visible';
-        //map.setLayoutProperty(layer.layerID, 'visibility', visibleVar);
       }
       // This is the case for coastal protection. Show the same output across
       // scales
@@ -726,13 +724,9 @@ const Map = () => {
 
   const changeLayerOrder = (servicesSorted) => {
     console.log("change order");
-    // Reverse the sorted services to start with the layers in the back
-    //const reversedServices = servicesSorted.slice().reverse();
-    //console.log("change order rev serv: ", reversedServices);
     console.log("change order serv: ", servicesSorted);
     console.log("change order vis lay: ", visibleLayers);
     const firstSymbolId = getMapStyleSymbolId(map);
-    //const zIndex = [firstSymbolId];
     let zIndex = [];
     if(basemapId !== 'satellite-v9') {
       zIndex = [firstSymbolId];


### PR DESCRIPTION
This bug was brought about after testing sorting but wasn't necessarily caused by sorting. Basically the bug was not being able to reliably redraw the z-index order when changing scale, changing basemaps, and changing visibility. This commit is a first pass at fixing that. It currently seems to function as expected.

The big thing I was missing was in how `map.moveLayer(layerId, beforeId)` was behaving. I was moving the least visible layers first "before" more visible layers. However, those more "visible" layers could be anywhere in the layering order, causing unexpected behavior. Thus, moving / setting the most visible layers first provided a stable way to get expected layering order.