### PR TITLE
Adding and styling close buttons to pop ups.

### DIFF
--- a/map-viewer/src/Map.css
+++ b/map-viewer/src/Map.css
@@ -106,6 +106,22 @@ canvas {
   color: #ffffff;
   font-size: 20px;
 }
+.service-info-close-col {
+  padding: 0;
+  padding-right: 0.3rem;
+}
+.service-info-close-button {
+  padding: 0.3rem;
+  font-size: 22px;
+  line-height: 22px;
+  background-color: transparent;
+  color: black;
+  border: 0;
+  border-radius: 0 0 0 0;
+}
+.service-info-close-button:hover {
+  background-color: #f58e87;
+}
 
 /* INFO BUTTON CSS */
 .btn {
@@ -288,6 +304,11 @@ canvas {
 }
 .mapboxgl-popup-close-button {
 /*display: none;*/
+  font-size: 24px;
+  padding: 0.3rem;
+}
+.mapboxgl-popup-close-button:hover {
+  background-color: #f58e87;
 }
 .mapboxgl-popup-content {
   font: 400 15px/22px 'Source Sans Pro', Sans-serif;

--- a/map-viewer/src/components/InfoPopover.jsx
+++ b/map-viewer/src/components/InfoPopover.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Popover from 'react-bootstrap/Popover';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
 
 import { BsInfoCircle} from 'react-icons/bs';
 
@@ -12,8 +14,21 @@ const InfoPopover = (props) => {
   if(props.title) {
     popover = (
       <Popover id="popover-service">
-        <Popover.Title>
-          {props.title}
+        <Popover.Title className="popover-service-title">
+          <Row>
+            <Col>
+              {props.title}
+            </Col>
+            <Col xs="auto" className="service-info-close-col">
+              <Button
+                className="service-info-close-button"
+                bsPrefix="popover-close-btn"
+                onClick={() => document.body.click()}
+              >
+              x
+              </Button>
+            </Col>
+          </Row>
         </Popover.Title>
         <Popover.Content>
           {props.content}

--- a/map-viewer/src/components/Legend.jsx
+++ b/map-viewer/src/components/Legend.jsx
@@ -131,6 +131,7 @@ const SortableItem = sortableElement(({value, index}) => (
         <Col xs="auto">
           <InfoPopover
             key={`legend-popover-${value}`}
+            title={legendStyle[value].name}
             content={legendStyle[value].info}
           />
         </Col>

--- a/map-viewer/src/components/ServicePopover.jsx
+++ b/map-viewer/src/components/ServicePopover.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Popover from 'react-bootstrap/Popover';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
 
 import { BsInfoCircle} from 'react-icons/bs';
 
@@ -31,7 +33,20 @@ const ServicePopover = (props) => {
   const popover = (
     <Popover id="popover-service" className="popover-service">
       <Popover.Title className="popover-service-title">
-        {props.title}
+        <Row>
+          <Col>
+            {props.title}
+          </Col>
+          <Col xs="auto" className="service-info-close-col">
+            <Button
+              className="service-info-close-button"
+              bsPrefix="popover-close-btn"
+              onClick={() => document.body.click()}
+            >
+            x 
+            </Button>
+          </Col>
+        </Row>
       </Popover.Title>
       <Popover.Content>
         <h5>Metric</h5>
@@ -71,7 +86,7 @@ const ServicePopover = (props) => {
 
   return (
     <OverlayTrigger trigger="click" rootClose={true} placement="right" overlay={popover}>
-      <Button variant="info" className="button-info" bsPrefix="info-btn">
+      <Button id="service-popover" variant="info" className="button-info" bsPrefix="info-btn">
         <BsInfoCircle />
       </Button>
     </OverlayTrigger>

--- a/map-viewer/src/components/VerticalMenu.jsx
+++ b/map-viewer/src/components/VerticalMenu.jsx
@@ -74,6 +74,7 @@ const VerticalMenu = (props) => {
                     <Col xs="auto" key={`form-col-popover-${scaleObj.id}`}>
                       <InfoPopover
                         key={`scale-popover-${scaleObj.id}`}
+                        title={scaleObj.name}
                         content={scaleObj.label}
                       />
                     </Col>


### PR DESCRIPTION
Styles close buttons on mapbox map popups to be bigger and more easily clicked.

Adds close buttons in top right to popovers for info buttons.

Resolves #81 