### PR TITLE
Add a layer visibility toggle in legend

### DIFF
--- a/map-viewer/src/Map.css
+++ b/map-viewer/src/Map.css
@@ -132,6 +132,24 @@ canvas {
   outline: none;
   box-shadow:none;
 }
+.btn-group-toggle>.button-eye input[type=checkbox] {
+  position: absolute;
+  clip: rect(0,0,0,0);
+  pointer-events: none;
+}
+.button-eye {
+  color: #000;
+  background-color:#fff;
+  font-size: 20px;
+  padding: 0;
+  padding-left: 0.0rem;
+  margin: 0;
+  border: 0;
+  outline-style: none;
+}
+.button-eye:hover {
+  cursor: pointer;
+}
 .button-info {
   background-color:transparent;
   font-size: 18px;
@@ -299,15 +317,20 @@ canvas {
 .legend-desc {
   z-index: 1;
   color: #000;
-  padding-left: 2px;
+  padding-left: 0px;
   padding-bottom: 5px;
   font-weight: bold;
   font-size: 13px;
+  margin-left: 0px;
 }
 .d3-legend {
   z-index: 1;
   width: 220px;
   height: auto;
+}
+.d3-legend-row {
+  padding-top: 5px;
+  margin-left: 0px;
 }
 .d3-legend.sequential{
   z-index: 1;
@@ -345,7 +368,7 @@ canvas {
 }
 .legend-item .col {
   padding: 0px;
-  margin-left: 15px;
+  margin-left: 0px;
 }
 .legend-item .col-auto {
   padding-left: 0px;

--- a/map-viewer/src/Map.jsx
+++ b/map-viewer/src/Map.jsx
@@ -1013,6 +1013,37 @@ const Map = () => {
     setBasemapChev(!basemapChev);
   }
 
+  const handleVisibilityChange = (serviceResult, checked) => {
+    console.log("service ", serviceResult);
+    console.log("checked ", checked);
+    let visibleLayersUpdate = {...layersRef.current};
+    console.log("change vis vis: ", visibleLayersUpdate);
+    let selectedServicesUpdate = [...selectedServices];
+    console.log("servicesRef current: ", selectedServicesUpdate);
+    if(!checked) {
+      if(serviceResult in multiFileLayers) {
+        multiFileLayers[serviceResult].forEach((childLayer) => {
+            map.setLayoutProperty(childLayer.id, 'visibility', 'none');
+        });
+      }
+      else {
+        const layer = layersRef.current[serviceResult];
+        map.setLayoutProperty(layer.layerID, 'visibility', 'none');
+      }
+    }
+    else {
+      if(serviceResult in multiFileLayers) {
+        multiFileLayers[serviceResult].forEach((childLayer) => {
+            map.setLayoutProperty(childLayer.id, 'visibility', 'visible');
+        });
+      }
+      else {
+        const layer = layersRef.current[serviceResult];
+        map.setLayoutProperty(layer.layerID, 'visibility', 'visible');
+      }
+      setMap(map);
+    }
+  }
 
   return (
       <Col className="map-container" >
@@ -1028,6 +1059,7 @@ const Map = () => {
           layers={visibleLayers}
           services={selectedServices}
           changeLayerOrder={changeLayerOrder}
+          handleVisibilityChange={handleVisibilityChange}
         />
         <Button
           onClick={changeBasemapControl}

--- a/map-viewer/src/components/Legend.jsx
+++ b/map-viewer/src/components/Legend.jsx
@@ -10,17 +10,14 @@ import Form from 'react-bootstrap/Form';
 
 import { FaChevronCircleUp, FaChevronCircleDown } from 'react-icons/fa';
 
-import D3Legend from './D3Legend';
-import InfoPopover from './InfoPopover';
+import SortableItem from './SortableItem';
 
 import {
   sortableContainer,
   sortableElement,
-  sortableHandle,
+  //sortableHandle,
 } from 'react-sortable-hoc';
 import {arrayMoveImmutable} from 'array-move';
-
-import { GrDrag } from 'react-icons/gr';
 
 const legendStyle = {
   'sediment': {
@@ -117,32 +114,14 @@ const legendStyle = {
   },
 }
 
-const DragHandle = sortableHandle(() => 
-  <span>{<GrDrag/>}</span>);
 
-const SortableItem = sortableElement(({value, index}) => (
-    <ListGroup.Item key={`legendStyle-${index}`} className="legend-item">
-      <Row>
-        <Col className="drag-handle" xs="auto">
-          <DragHandle />
-        </Col>
-        <Col className="legend-desc" xs="auto">
-          {legendStyle[value].desc}
-        </Col>
-      </Row>
-      <Row>
-        <Col>
-          <D3Legend serviceType={value} legendStyle={legendStyle}/>
-        </Col>
-        <Col xs="auto">
-          <InfoPopover
-            key={`legend-popover-${value}`}
-            title={legendStyle[value].name}
-            content={legendStyle[value].info}
-          />
-        </Col>
-      </Row>
-    </ListGroup.Item>
+const ItemSortable = sortableElement(({value, index, handleVisibilityChange}) => (
+  <SortableItem
+    value={value}
+    index={index}
+    legendStyle={legendStyle}
+    handleVisibilityChange={handleVisibilityChange}
+  />
 ));
 
 const SortableContainer = sortableContainer(({children}) => {
@@ -157,14 +136,19 @@ const Legend = (props) => {
     const sortedServices = arrayMoveImmutable(props.services, oldIndex, newIndex);
     props.changeLayerOrder(sortedServices, oldIndex, newIndex);
   }
+  function handleVisibilityChange(serviceValue, visibilityBool) {
+    console.log("Legend vis change: ", serviceValue, visibilityBool);
+    props.handleVisibilityChange(serviceValue, visibilityBool);
+  }
 
   const renderLegend = (serviceType, i) => {
       return (
-        <SortableItem
+        <ItemSortable
           className="sortable-item"
           key={`item-${serviceType}-${i}`}
-          index={i}
-          value={serviceType} />
+          index={`${i}`}
+          value={serviceType}
+          handleVisibilityChange={handleVisibilityChange}/>
       );
   };
 
@@ -212,6 +196,7 @@ Legend.propTypes = {
   layers: PropTypes.object.isRequired,
   services: PropTypes.array.isRequired,
   changeLayerOrder: PropTypes.func.isRequired,
+  handleVisibilityChange: PropTypes.func.isRequired,
 }
 
 export default Legend;

--- a/map-viewer/src/components/SortableItem.jsx
+++ b/map-viewer/src/components/SortableItem.jsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import ListGroup from 'react-bootstrap/ListGroup';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import ToggleButton from 'react-bootstrap/ToggleButton';
+
+import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
+
+import D3Legend from './D3Legend';
+import InfoPopover from './InfoPopover';
+
+import { GrDrag } from 'react-icons/gr';
+
+import {
+//  sortableElement,
+  sortableHandle,
+} from 'react-sortable-hoc';
+
+const SortableItem = (props) => {
+  const [checked, setChecked] = useState(true);
+
+  function handleVisibilityChange(event) {
+    setChecked(event.currentTarget.checked);
+    console.log("eye event: ", event.target);
+    const { value, checked } = event.currentTarget;
+    console.log("eye target: ", value, checked);
+    props.handleVisibilityChange(value, checked);
+  }
+
+  const DragHandle = sortableHandle(() =>
+    <span>{<GrDrag/>}</span>);
+
+  return (
+    <ListGroup.Item key={`legendStyle-${props.index}`} className="legend-item">
+      <Row>
+        <Col className="drag-handle" xs="auto">
+          <DragHandle />
+        </Col>
+        <Col className="legend-desc">
+          {props.legendStyle[props.value].desc}
+        </Col>
+        <Col xs="auto">
+          <ButtonGroup toggle>
+            <ToggleButton
+              id={props.value}
+              type="checkbox"
+              variant="secondary"
+              checked={checked}
+              value={props.value}
+              onChange={handleVisibilityChange}
+              className="button-eye"
+              bsPrefix="info-btn"
+             >
+              {checked ? <AiOutlineEye/> : <AiOutlineEyeInvisible/>}
+            </ToggleButton>
+          </ButtonGroup>
+        </Col>
+      </Row>
+      <Row className="d3-legend-row">
+        <Col>
+          <D3Legend serviceType={props.value} legendStyle={props.legendStyle}/>
+        </Col>
+        <Col xs="auto">
+          <InfoPopover
+            key={`legend-popover-${props.value}`}
+            title={props.legendStyle[props.value].name}
+            content={props.legendStyle[props.value].info}
+          />
+        </Col>
+      </Row>
+    </ListGroup.Item>
+  );
+};
+
+SortableItem.propTypes = {
+  value: PropTypes.string.isRequired,
+  index: PropTypes.string.isRequired,
+  legendStyle: PropTypes.object.isRequired,
+  handleVisibilityChange: PropTypes.func.isRequired,
+}
+
+export default SortableItem;


### PR DESCRIPTION
Add an "eye" icon to each legend entry that when clicked toggles the
visibility of that layer on / off. The layer still remains "selected",
only the visibility is effected.

Updates issue #32 